### PR TITLE
Ensure run_edge can import project modules

### DIFF
--- a/apps/run_edge.py
+++ b/apps/run_edge.py
@@ -13,6 +13,10 @@ import numpy as np
 import yaml
 from paho.mqtt import client as mqtt
 
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
 from common.events import DetectionEvent
 from common.loader import load_object
 from common.quality import sharpness_laplacian


### PR DESCRIPTION
## Summary
- insert the repository root onto sys.path before importing project modules in run_edge

## Testing
- python apps/run_edge.py -h *(fails: ImportError: libGL.so.1 missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd7d4c2748832d844a611e1ce5f4e7