### PR TITLE
Add Ultralytics YOLO PT adapter

### DIFF
--- a/configs/edge_pi5_stage1.yaml
+++ b/configs/edge_pi5_stage1.yaml
@@ -1,0 +1,42 @@
+edge:
+  cam_id: "pi5_cam_a"
+  fps: 1.0
+  emit_jsonl: "data/tracks.jsonl"
+  mqtt: null  # e.g., "mqtts://user:pass@host:8883/topic"
+
+intuitus:
+  enabled: true
+  impl: "intuitus.roi_diff:DiffROI"
+  keyframe_sec: 2.0
+  min_blob_area: 300
+  dilate: 11
+  max_roi: 8
+  max_area_frac: 0.4
+
+quiddity:
+  impl: "quiddity.yoloe_pt:YOLOEPT"
+  model_path: "models/yoloe-v8-S.pt"   # direct PyTorch weights
+  conf_th: 0.35
+  classes_include: ["person"]
+
+tracker:
+  impl: "common.tracker_sort:Sort"
+  iou_th: 0.3
+  max_age: 12
+
+haecceity:
+  new_id_threshold: 0.55
+  hysteresis: 0.05
+  min_bbox_h_frac: 0.08
+  min_sharpness: 25.0
+  embed_interval_frames: 3
+  specialists:
+    - impl: "haecceity.person_osnet:PersonOSNet025"
+      model_path: "models/osnet_x0_25.onnx"
+      crop: 192
+    - impl: "haecceity.vehicle_signature:VehicleSignature"
+      hist_bins: 32
+  fallbacks:
+    - impl: "haecceity.generic_osnet:GenericOSNet025"
+      model_path: "models/osnet_x0_25.onnx"
+      crop: 192

--- a/quiddity/yoloe_pt.py
+++ b/quiddity/yoloe_pt.py
@@ -1,0 +1,40 @@
+from typing import List, Tuple
+
+import numpy as np
+from ultralytics import YOLO
+
+from common.interfaces import BBox, Detector
+
+
+class YOLOEPT(Detector):
+    """
+    Wraps Ultralytics YOLOE (PyTorch .pt weights).
+
+    Config keys (example):
+      quiddity:
+        impl: "quiddity.yoloe_pt:YOLOEPT"
+        model_path: "models/yoloe-v8-S.pt"
+        conf_th: 0.35
+        classes_include: ["person"]
+    """
+
+    def __init__(self, cfg: dict):
+        self.model_path = cfg["model_path"]
+        self.conf_th = float(cfg.get("conf_th", 0.35))
+        self.classes_include = cfg.get("classes_include")
+        self.model = YOLO(self.model_path)
+
+    def detect(self, frame_bgr: np.ndarray) -> List[Tuple[BBox, float, str]]:
+        results = self.model.predict(frame_bgr, verbose=False)[0]
+        out: List[Tuple[BBox, float, str]] = []
+        for box in results.boxes:
+            conf = float(box.conf.item())
+            if conf < self.conf_th:
+                continue
+            cls_id = int(box.cls.item())
+            cls_name = self.model.names.get(cls_id, str(cls_id))
+            if self.classes_include and cls_name not in self.classes_include:
+                continue
+            x1, y1, x2, y2 = map(int, box.xyxy[0].tolist())
+            out.append(((x1, y1, x2, y2), conf, cls_name))
+        return out

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 numpy
 opencv-python
-onnxruntime
+onnxruntime        # keep for Stage-2/ONNX path
 paho-mqtt
 pyyaml
 filterpy
+ultralytics        # NEW (for .pt inference + retraining)


### PR DESCRIPTION
## Summary
- add an Ultralytics-based YOLOE detector adapter that loads native .pt weights
- add a Stage-1 Pi config pointing Quiddity to the PT model
- include ultralytics in the runtime requirements to support PyTorch inference

## Testing
- `python -m compileall quiddity/yoloe_pt.py`


------
https://chatgpt.com/codex/tasks/task_e_68d19c51936c832d8d08148336b977b7