### PR TITLE
Add YOLOv8 alias loader and stage1 runner

### DIFF
--- a/apps/run_stage1.py
+++ b/apps/run_stage1.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+import os
+import time
+import argparse
+import json
+import pathlib
+import yaml
+import cv2
+from common.events import DetectionEvent
+from common.loader import load_object
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("-c", "--config", required=True)
+    args = ap.parse_args()
+    cfg = yaml.safe_load(open(args.config))
+
+    cam_id = cfg["edge"]["cam_id"]
+    src = cfg["edge"]["source"]
+    fps = float(cfg["edge"]["fps"])
+    out_path = cfg["edge"]["emit_jsonl"]
+    pathlib.Path(os.path.dirname(out_path)).mkdir(parents=True, exist_ok=True)
+    out = open(out_path, "a", buffering=1)
+
+    det_impl = load_object(cfg["quiddity"]["impl"])
+    detector = det_impl(cfg["quiddity"])
+
+    cap = cv2.VideoCapture(src)
+    if not cap.isOpened():
+        raise SystemExit(f"Could not open source: {src}")
+
+    period = 1.0 / max(0.1, fps)
+    last = 0.0
+    frame_idx = 0
+    ema_fps = None
+
+    try:
+        while True:
+            now = time.time()
+            if now - last < period:
+                time.sleep(0.002)
+                continue
+            last = now
+
+            ok, frame = cap.read()
+            if not ok:
+                break
+            H, W = frame.shape[:2]
+
+            t0 = time.time()
+            dets = detector.detect(frame)
+            infer_ms = (time.time() - t0) * 1000.0
+
+            for (x1, y1, x2, y2), conf, clazz in dets:
+                ev = DetectionEvent(
+                    ts_ms=int(time.time() * 1000),
+                    cam_id=cam_id,
+                    frame=frame_idx,
+                    track_id_local=-1,
+                    global_id=None,
+                    clazz=clazz,
+                    conf=float(conf),
+                    box_xyxy=(int(x1), int(y1), int(x2), int(y2)),
+                    img_wh=(int(W), int(H)),
+                    have_embed=False,
+                    specialist=None,
+                    quality=None,
+                )
+                out.write(ev.to_json() + "\n")
+
+            inst_fps = 1000.0 / max(1.0, infer_ms)
+            ema_fps = inst_fps if ema_fps is None else 0.9 * ema_fps + 0.1 * inst_fps
+            print(
+                f"frame {frame_idx} | dets {len(dets)} | infer {infer_ms:.1f} ms | ~{ema_fps:.2f} FPS"
+            )
+
+            frame_idx += 1
+    except KeyboardInterrupt:
+        pass
+    finally:
+        out.close()
+        cap.release()
+        cv2.destroyAllWindows()
+
+
+if __name__ == "__main__":
+    main()

--- a/configs/edge_pi5_stage1.yaml
+++ b/configs/edge_pi5_stage1.yaml
@@ -1,42 +1,11 @@
 edge:
   cam_id: "pi5_cam_a"
   fps: 1.0
-  emit_jsonl: "data/tracks.jsonl"
-  mqtt: null  # e.g., "mqtts://user:pass@host:8883/topic"
-
-intuitus:
-  enabled: true
-  impl: "intuitus.roi_diff:DiffROI"
-  keyframe_sec: 2.0
-  min_blob_area: 300
-  dilate: 11
-  max_roi: 8
-  max_area_frac: 0.4
+  source: 0
+  emit_jsonl: "data/stage1_tracks.jsonl"
 
 quiddity:
   impl: "quiddity.yoloe_pt:YOLOEPT"
-  model_path: "models/yoloe-v8-S.pt"   # direct PyTorch weights
+  model_name: "yolov8s"          # Ultralytics alias; auto-downloads on first run
   conf_th: 0.35
   classes_include: ["person"]
-
-tracker:
-  impl: "common.tracker_sort:Sort"
-  iou_th: 0.3
-  max_age: 12
-
-haecceity:
-  new_id_threshold: 0.55
-  hysteresis: 0.05
-  min_bbox_h_frac: 0.08
-  min_sharpness: 25.0
-  embed_interval_frames: 3
-  specialists:
-    - impl: "haecceity.person_osnet:PersonOSNet025"
-      model_path: "models/osnet_x0_25.onnx"
-      crop: 192
-    - impl: "haecceity.vehicle_signature:VehicleSignature"
-      hist_bins: 32
-  fallbacks:
-    - impl: "haecceity.generic_osnet:GenericOSNet025"
-      model_path: "models/osnet_x0_25.onnx"
-      crop: 192

--- a/quiddity/yoloe_pt.py
+++ b/quiddity/yoloe_pt.py
@@ -1,40 +1,37 @@
 from typing import List, Tuple
-
 import numpy as np
 from ultralytics import YOLO
-
-from common.interfaces import BBox, Detector
+from common.interfaces import Detector, BBox
 
 
 class YOLOEPT(Detector):
     """
-    Wraps Ultralytics YOLOE (PyTorch .pt weights).
-
-    Config keys (example):
+    Ultralytics YOLO wrapper that loads by alias or URL (auto-downloads).
+    Config keys:
       quiddity:
         impl: "quiddity.yoloe_pt:YOLOEPT"
-        model_path: "models/yoloe-v8-S.pt"
+        model_name: "yolov8s"        # alias; Ultralytics downloads + caches
         conf_th: 0.35
-        classes_include: ["person"]
+        classes_include: ["person"]  # optional filter
     """
 
     def __init__(self, cfg: dict):
-        self.model_path = cfg["model_path"]
         self.conf_th = float(cfg.get("conf_th", 0.35))
         self.classes_include = cfg.get("classes_include")
-        self.model = YOLO(self.model_path)
+        model_name = cfg.get("model_name", "yolov8s")  # default alias
+        self.model = YOLO(model_name)  # no file path needed
 
     def detect(self, frame_bgr: np.ndarray) -> List[Tuple[BBox, float, str]]:
-        results = self.model.predict(frame_bgr, verbose=False)[0]
+        res = self.model.predict(frame_bgr, verbose=False)[0]
         out: List[Tuple[BBox, float, str]] = []
-        for box in results.boxes:
-            conf = float(box.conf.item())
+        for b in res.boxes:
+            conf = float(b.conf.item())
             if conf < self.conf_th:
                 continue
-            cls_id = int(box.cls.item())
+            cls_id = int(b.cls.item())
             cls_name = self.model.names.get(cls_id, str(cls_id))
             if self.classes_include and cls_name not in self.classes_include:
                 continue
-            x1, y1, x2, y2 = map(int, box.xyxy[0].tolist())
+            x1, y1, x2, y2 = map(int, b.xyxy[0].tolist())
             out.append(((x1, y1, x2, y2), conf, cls_name))
         return out

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ onnxruntime        # keep for Stage-2/ONNX path
 paho-mqtt
 pyyaml
 filterpy
-ultralytics        # NEW (for .pt inference + retraining)
+ultralytics          # NEW (for .pt alias auto-download)


### PR DESCRIPTION
## Summary
- add ultralytics dependency for alias-based YOLOv8 downloads
- implement YOLOEPT detector wrapper that loads models by alias or URL
- provide stage-1 configuration and runner that emit detection events

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d1b6dde3c8832d82b1d180619eefa8