### PR TITLE
Refactor video helpers into shared module

### DIFF
--- a/apps/run_edge.py
+++ b/apps/run_edge.py
@@ -21,6 +21,7 @@ if str(REPO_ROOT) not in sys.path:
 from common.events import DetectionEvent
 from common.loader import load_object
 from common.quality import sharpness_laplacian
+from .video_utils import open_source
 
 BBox = Tuple[int, int, int, int]
 
@@ -49,79 +50,6 @@ class _PassthroughTracker:
         return tracks
 
 LOGGER = logging.getLogger("haecceity.edge")
-
-
-def open_source(src, fps):
-    """
-    Returns a tuple (read_fn, close_fn, size_fn)
-      - read_fn() -> (ok, frame_bgr)
-      - close_fn() -> None
-      - size_fn() -> (W, H) after first frame
-    Supports:
-      - "picam"     -> Picamera2 capture_array()
-      - int/index   -> OpenCV VideoCapture(index)
-      - path/rtsp   -> OpenCV VideoCapture(url)
-    """
-
-    if isinstance(src, str) and src.lower() == "picam":
-        try:
-            from picamera2 import Picamera2
-        except Exception as exc:
-            raise SystemExit(
-                "Picamera2 not available. Install with: sudo apt install -y python3-picamera2"
-            ) from exc
-
-        picam = Picamera2()
-        config = picam.create_video_configuration({"size": (1280, 720)})
-        picam.configure(config)
-        picam.start()
-        time.sleep(0.3)
-        first = picam.capture_array()
-        height, width = first.shape[:2]
-
-        def read_fn():
-            frame = picam.capture_array()
-            return True, frame
-
-        def close_fn():
-            try:
-                picam.stop()
-            except Exception:
-                pass
-
-        def size_fn():
-            return (width, height)
-
-        return read_fn, close_fn, size_fn
-
-    cap = cv2.VideoCapture(src)
-    if not cap.isOpened():
-        raise SystemExit(f"Could not open source: {src}")
-
-    ok, frame = cap.read()
-    if not ok:
-        cap.release()
-        raise SystemExit(f"Failed to read first frame from source: {src}")
-    height, width = frame.shape[:2]
-
-    try:
-        cap.set(cv2.CAP_PROP_POS_FRAMES, 0)
-    except Exception:
-        pass
-
-    def read_fn():
-        ok, f = cap.read()
-        return ok, f
-
-    def close_fn():
-        cap.release()
-
-    def size_fn():
-        return (width, height)
-
-    return read_fn, close_fn, size_fn
-
-
 def _instantiate_from_config(entry: dict):
     impl = entry["impl"]
     cls = load_object(impl)

--- a/apps/run_stage1.py
+++ b/apps/run_stage1.py
@@ -3,31 +3,7 @@ import os, time, argparse, json, pathlib, yaml, sys
 import numpy as np
 import cv2
 
-
-def to_bgr(frame):
-    """
-    Normalize frames from any source (RGB, BGR, RGBA/BGRA, GRAY) to BGR (H,W,3).
-
-    Picamera2 often yields RGB or BGRA; OpenCV/USB usually yields BGR.
-    This function returns a 3-channel BGR array suitable for Ultralytics.
-    """
-    if frame is None:
-        return None
-    if frame.ndim == 2:
-        # GRAY -> BGR
-        return cv2.cvtColor(frame, cv2.COLOR_GRAY2BGR)
-    if frame.ndim != 3:
-        raise ValueError(f"Unexpected frame ndim={frame.ndim}, expected 2 or 3.")
-    h, w, c = frame.shape
-    if c == 3:
-        # Heuristic: Picamera2 default is RGB; convert to BGR for consistency.
-        # If the source is already BGR, this conversion is harmless for YOLO.
-        return cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
-    if c == 4:
-        # Many Pi pipelines produce XRGB/BGRA; try BGRA->BGR first.
-        # If colors look off, switch to cv2.COLOR_RGBA2BGR.
-        return cv2.cvtColor(frame, cv2.COLOR_BGRA2BGR)
-    raise ValueError(f"Unexpected channel count: {c}, expected 1/3/4.")
+from .video_utils import open_source, to_bgr
 
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -36,78 +12,6 @@ if str(REPO_ROOT) not in sys.path:
 
 from common.events import DetectionEvent
 from common.loader import load_object
-
-
-def open_source(src, fps):
-    """
-    Returns a tuple (read_fn, close_fn, size_fn)
-      - read_fn() -> (ok, frame_bgr)
-      - close_fn() -> None
-      - size_fn() -> (W, H) after first frame
-    Supports:
-      - "picam"     -> Picamera2 capture_array()
-      - int/index   -> OpenCV VideoCapture(index)
-      - path/rtsp   -> OpenCV VideoCapture(url)
-    """
-    if isinstance(src, str) and src.lower() == "picam":
-        try:
-            from picamera2 import Picamera2
-        except Exception as e:
-            raise SystemExit("Picamera2 not available. Install with: sudo apt install -y python3-picamera2") from e
-
-        picam = Picamera2()
-        # 1280x720 is a good default; adjust if you want
-        config = picam.create_video_configuration({"size": (1280, 720)})
-        picam.configure(config)
-        picam.start()
-        time.sleep(0.3)
-        first = picam.capture_array()
-        H, W = first.shape[:2]
-
-        def read_fn():
-            frame = picam.capture_array()
-            return True, frame
-
-        def close_fn():
-            try:
-                picam.stop()
-            except Exception:
-                pass
-
-        def size_fn():
-            return (W, H)
-
-        return read_fn, close_fn, size_fn
-
-    # else OpenCV path
-    cap = cv2.VideoCapture(src)
-    if not cap.isOpened():
-        raise SystemExit(f"Could not open source: {src}")
-
-    # Warm up to get size
-    ok, frame = cap.read()
-    if not ok:
-        cap.release()
-        raise SystemExit(f"Failed to read first frame from source: {src}")
-    H, W = frame.shape[:2]
-
-    # Rewind if it was a file
-    try:
-        cap.set(cv2.CAP_PROP_POS_FRAMES, 0)
-    except Exception:
-        pass
-
-    def read_fn():
-        ok, f = cap.read()
-        return ok, f
-
-    def close_fn():
-        cap.release()
-
-    def size_fn():
-        return (W, H)
-
-    return read_fn, close_fn, size_fn
 
 
 def main():

--- a/apps/video_utils.py
+++ b/apps/video_utils.py
@@ -1,0 +1,94 @@
+"""Shared video source utilities."""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Callable, Tuple
+
+import cv2
+
+
+FrameReadFn = Callable[[], Tuple[bool, Any]]
+FrameCloseFn = Callable[[], None]
+FrameSizeFn = Callable[[], Tuple[int, int]]
+
+
+def to_bgr(frame):
+    """Normalize frames from any source to a 3-channel BGR array."""
+    if frame is None:
+        return None
+    if frame.ndim == 2:
+        # GRAY -> BGR
+        return cv2.cvtColor(frame, cv2.COLOR_GRAY2BGR)
+    if frame.ndim != 3:
+        raise ValueError(f"Unexpected frame ndim={frame.ndim}, expected 2 or 3.")
+    height, width, channels = frame.shape
+    if channels == 3:
+        # Heuristic: Picamera2 default is RGB; convert to BGR for consistency.
+        return cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
+    if channels == 4:
+        # Many Pi pipelines produce XRGB/BGRA; try BGRA->BGR first.
+        return cv2.cvtColor(frame, cv2.COLOR_BGRA2BGR)
+    raise ValueError(f"Unexpected channel count: {channels}, expected 1/3/4.")
+
+
+def open_source(src, fps):
+    """Return read/close/size helpers for a camera source."""
+
+    if isinstance(src, str) and src.lower() == "picam":
+        try:
+            from picamera2 import Picamera2
+        except Exception as exc:  # pragma: no cover - hardware dependency
+            raise SystemExit(
+                "Picamera2 not available. Install with: sudo apt install -y python3-picamera2"
+            ) from exc
+
+        picam = Picamera2()
+        config = picam.create_video_configuration({"size": (1280, 720)})
+        picam.configure(config)
+        picam.start()
+        time.sleep(0.3)
+        first = picam.capture_array()
+        height, width = first.shape[:2]
+
+        def read_fn():
+            frame = picam.capture_array()
+            return True, frame
+
+        def close_fn():
+            try:
+                picam.stop()
+            except Exception:
+                pass
+
+        def size_fn():
+            return (width, height)
+
+        return read_fn, close_fn, size_fn
+
+    cap = cv2.VideoCapture(src)
+    if not cap.isOpened():
+        raise SystemExit(f"Could not open source: {src}")
+
+    ok, frame = cap.read()
+    if not ok:
+        cap.release()
+        raise SystemExit(f"Failed to read first frame from source: {src}")
+    height, width = frame.shape[:2]
+
+    try:
+        cap.set(cv2.CAP_PROP_POS_FRAMES, 0)
+    except Exception:
+        pass
+
+    def read_fn():
+        ok, frame_local = cap.read()
+        return ok, frame_local
+
+    def close_fn():
+        cap.release()
+
+    def size_fn():
+        return (width, height)
+
+    return read_fn, close_fn, size_fn


### PR DESCRIPTION
## Summary
- add a shared apps/video_utils module with reusable to_bgr and open_source helpers
- update run_stage1 and run_edge to use the shared helpers instead of local copies

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d23ccaaff8832d8a633ca59bb1e0f7