### PR TITLE
Gate embeddings by allowlisted classes

### DIFF
--- a/configs/edge_pi5_stage1.yaml
+++ b/configs/edge_pi5_stage1.yaml
@@ -8,4 +8,25 @@ quiddity:
   impl: "quiddity.yoloe_pt:YOLOEPT"
   model_name: "yolov8s"          # Ultralytics alias; auto-downloads on first run
   conf_th: 0.35
-  classes_include: ["person"]
+  # classes_include: ["person"]  # Emit all classes when omitted
+
+tracker:
+  impl: null
+
+haecceity:
+  new_id_threshold: 0.55
+  hysteresis: 0.05
+  min_bbox_h_frac: 0.08
+  min_sharpness: 25.0
+  embed_interval_frames: 3
+  embed_classes: ["person", "car"]
+  specialists:
+    - impl: "haecceity.person_osnet:PersonOSNet025"
+      model_path: "models/osnet_x0_25.onnx"
+      crop: 192
+    - impl: "haecceity.vehicle_signature:VehicleSignature"
+      hist_bins: 32
+  fallbacks:
+    - impl: "haecceity.generic_osnet:GenericOSNet025"
+      model_path: "models/osnet_x0_25.onnx"
+      crop: 192


### PR DESCRIPTION
## Summary
- update the stage 1 edge config to emit all YOLO classes while defining the embedding allowlist
- read the embed class allowlist in the edge runner and only run specialists for those classes

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d2c2bd36e0832d81b7e3fbf1e4342c