### PR TITLE
Add numpy exceptions compatibility shim

### DIFF
--- a/common/numpy_compat.py
+++ b/common/numpy_compat.py
@@ -1,0 +1,34 @@
+"""Compatibility helpers for differing NumPy versions.
+
+This module ensures that optional submodules expected by some third-party
+libraries are available even when running on older NumPy releases.  It should
+be imported before any library that requires these compatibility shims.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+try:  # pragma: no cover - simple import guard
+    import numpy.exceptions  # type: ignore[attr-defined]
+except ModuleNotFoundError:  # pragma: no cover - executed only on older NumPy
+    import numpy as _np
+
+    # NumPy introduced ``numpy.exceptions.AxisError`` in newer versions. Older
+    # releases (such as 1.24) still expose ``AxisError`` either as an attribute
+    # of the top-level ``numpy`` package or from ``numpy.core._exceptions``.
+    AxisError = getattr(_np, "AxisError", None)
+
+    if AxisError is None:  # pragma: no cover - depends on NumPy version
+        try:
+            from numpy.core._exceptions import AxisError  # type: ignore
+        except Exception:  # pragma: no cover - safeguard for unexpected setups
+            AxisError = None
+
+    shim = types.ModuleType("numpy.exceptions")
+
+    if AxisError is not None:
+        shim.AxisError = AxisError
+
+    sys.modules.setdefault("numpy.exceptions", shim)

--- a/tracker/sort.py
+++ b/tracker/sort.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import List, Tuple
 
+from common import numpy_compat  # noqa: F401  Ensures NumPy compatibility shims are applied.
 import numpy as np
 from filterpy.kalman import KalmanFilter
 


### PR DESCRIPTION
## Summary
- provide a numpy.exceptions compatibility shim so SciPy can import AxisError on older NumPy versions
- import the compatibility shim from the SORT tracker before loading FilterPy

## Testing
- python3 apps/run_edge.py --config configs/edge_pi5_stage1.yaml *(fails: ImportError: libGL.so.1 missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2dc6a7134832da427edc984bb122a