### PR TITLE
Improve SORT association for prop-carrying people

### DIFF
--- a/common/geometry.py
+++ b/common/geometry.py
@@ -1,0 +1,45 @@
+"""Geometry helpers for tracker association tweaks."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+BBox = Tuple[float, float, float, float]
+
+
+def box_center(x1: float, y1: float, x2: float, y2: float) -> Tuple[float, float]:
+    """Return the center point of an ``(x1, y1, x2, y2)`` box."""
+
+    return (x1 + x2) / 2.0, (y1 + y2) / 2.0
+
+
+def shrink_box(
+    x1: float, y1: float, x2: float, y2: float, shrink: float
+) -> Tuple[float, float, float, float]:
+    """Shrink a box by ``shrink`` fraction on each side."""
+
+    w = x2 - x1
+    h = y2 - y1
+    nx1 = x1 + 0.5 * w * shrink
+    ny1 = y1 + 0.5 * h * shrink
+    nx2 = x2 - 0.5 * w * shrink
+    ny2 = y2 - 0.5 * h * shrink
+    return nx1, ny1, nx2, ny2
+
+
+def core_center(x1: float, y1: float, x2: float, y2: float, shrink: float) -> Tuple[float, float]:
+    """Return the center of the shrunk ``core`` box."""
+
+    sx1, sy1, sx2, sy2 = shrink_box(x1, y1, x2, y2, shrink)
+    return box_center(sx1, sy1, sx2, sy2)
+
+
+def dilate_box(
+    x1: float, y1: float, x2: float, y2: float, dx: float, dy: float
+) -> Tuple[float, float, float, float]:
+    """Dilate a box by ``dx``/``dy`` fractions per axis for association only."""
+
+    w = x2 - x1
+    h = y2 - y1
+    return x1 - w * dx, y1 - h * dy, x2 + w * dx, y2 + h * dy
+

--- a/configs/edge_pi5.yaml
+++ b/configs/edge_pi5.yaml
@@ -22,9 +22,28 @@ quiddity:
   classes_include: ["person", "car"]
 
 tracker:
-  impl: "common.tracker_sort:Sort"
-  iou_th: 0.3
+  impl: "tracker.sort:SORT"
+  iou_threshold: 0.3
   max_age: 12
+  min_hits: 2
+  class_consistency:
+    enabled: true
+    penalty: 1000000
+  core_center:
+    enabled: true
+    shrink: 0.30
+  scale_gate:
+    enabled: true
+    grow_tol: 1.60
+    shrink_tol: 0.60
+  dilate_for_assoc:
+    enabled: true
+    dx: 0.15
+    dy: 0.05
+  duplicate_merge:
+    enabled: true
+    iou_thresh: 0.6
+    min_frames: 3
 
 haecceity:
   new_id_threshold: 0.55

--- a/tests/test_tracker_costs.py
+++ b/tests/test_tracker_costs.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import math
+
+import pathlib
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from common.geometry import core_center, dilate_box, shrink_box
+from tracker.costs import class_mismatch_penalty, normalized_l2, within_asym_scale_gate
+
+
+def test_class_mismatch_penalty() -> None:
+    assert class_mismatch_penalty("person", "person", 100.0) == 0.0
+    assert class_mismatch_penalty("person", "box", 100.0) == 100.0
+
+
+def test_shrink_and_core_center() -> None:
+    box = (0.0, 0.0, 10.0, 20.0)
+    shrunk = shrink_box(*box, 0.2)
+    # 20% trimmed from each side → width 6, height 12
+    assert shrunk == (1.0, 2.0, 9.0, 18.0)
+    cx, cy = core_center(*box, 0.2)
+    assert cx == 5.0
+    assert cy == 10.0
+
+
+def test_within_asym_scale_gate() -> None:
+    assert within_asym_scale_gate((10.0, 10.0), (14.0, 14.0), 1.6, 0.6)
+    assert within_asym_scale_gate((10.0, 10.0), (6.0, 6.0), 1.6, 0.6)
+    assert not within_asym_scale_gate((10.0, 10.0), (20.0, 20.0), 1.6, 0.6)
+    assert not within_asym_scale_gate((10.0, 10.0), (5.0, 8.0), 1.6, 0.6)
+
+
+def test_dilate_box() -> None:
+    dilated = dilate_box(0.0, 0.0, 10.0, 20.0, 0.1, 0.05)
+    assert dilated == (-1.0, -1.0, 11.0, 21.0)
+
+
+def test_normalized_l2() -> None:
+    dist = normalized_l2((5.0, 5.0), (6.0, 9.0), (10.0, 10.0))
+    assert math.isclose(dist, math.hypot(0.1, 0.4))
+    assert normalized_l2((0.0, 0.0), (0.0, 0.0), None) == 0.0
+

--- a/tracker/README.md
+++ b/tracker/README.md
@@ -14,3 +14,44 @@ tracker:
 ```
 
 At 1 FPS, `max_age: 10` ≈ 10 seconds of occlusion tolerance.
+
+## Prop-Robust Association
+
+People carrying large props (bags, boxes, umbrellas) can quickly change shape.
+Enable the prop-aware association knobs to keep a single `person` track alive
+through these transitions:
+
+```yaml
+tracker:
+  impl: "tracker.sort:SORT"
+  class_consistency:
+    enabled: true          # refuse cross-class swaps when matching
+    penalty: 1000000       # huge cost ⇒ practical hard constraint
+  core_center:
+    enabled: true          # focus on torso center instead of extremities
+    shrink: 0.30           # crop 30% from each side before centering
+  scale_gate:
+    enabled: true          # asymmetric scale tolerance (growth > shrink)
+    grow_tol: 1.60         # allow +60% jump vs. prediction
+    shrink_tol: 0.60       # allow -40% drop vs. prediction
+  dilate_for_assoc:
+    enabled: true          # inflate predicted boxes for matching only
+    dx: 0.15               # widen ±15% (total width ×1.30)
+    dy: 0.05               # grow height modestly
+  duplicate_merge:
+    enabled: true          # collapse overlapping duplicates post-update
+    iou_thresh: 0.6
+    min_frames: 3
+```
+
+- **Class consistency**: prevents ID theft by penalizing mismatched classes.
+- **Core center**: uses a torso-like center for `person` tracks/detections so
+  swinging arms or props have less influence.
+- **Scale gate**: allows a person to grow quickly (due to props) while still
+  rejecting implausible shrinkage.
+- **Dilate for association**: expands predicted `person` regions before scoring
+  IoU/centers; rendering still uses the original boxes.
+- **Duplicate merge**: after updates, combines overlapping tracks of the same
+  class that survived at least `min_frames`.
+
+Disable any feature via `enabled: false` to revert to legacy behavior.

--- a/tracker/costs.py
+++ b/tracker/costs.py
@@ -1,0 +1,51 @@
+"""Association helpers for SORT-like trackers."""
+
+from __future__ import annotations
+
+import math
+from typing import Iterable, Tuple
+
+
+def class_mismatch_penalty(trk_cls: str, det_cls: str, penalty: float) -> float:
+    """Return penalty if classes differ."""
+
+    return penalty if trk_cls != det_cls else 0.0
+
+
+def within_asym_scale_gate(
+    pred_wh: Tuple[float, float],
+    det_wh: Tuple[float, float],
+    grow_tol: float,
+    shrink_tol: float,
+) -> bool:
+    """Check asymmetric scale tolerances for width/height."""
+
+    pw, ph = pred_wh
+    dw, dh = det_wh
+    if pw <= 0 or ph <= 0:
+        return True
+    okw = shrink_tol * pw <= dw <= grow_tol * pw
+    okh = shrink_tol * ph <= dh <= grow_tol * ph
+    return okw and okh
+
+
+def normalized_l2(
+    p1: Tuple[float, float],
+    p2: Tuple[float, float],
+    norm: Iterable[float] | None,
+) -> float:
+    """Normalized Euclidean distance between two points."""
+
+    if norm is None:
+        nx = ny = 1.0
+    else:
+        norm_iter = list(norm)
+        if len(norm_iter) < 2:
+            nx = ny = 1.0
+        else:
+            nx = float(norm_iter[0]) or 1.0
+            ny = float(norm_iter[1]) or 1.0
+    dx = (p1[0] - p2[0]) / nx
+    dy = (p1[1] - p2[1]) / ny
+    return math.hypot(dx, dy)
+

--- a/tracker/sort.py
+++ b/tracker/sort.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
-from typing import List, Tuple
+from typing import Dict, Iterable, List, Tuple
 
 from common import numpy_compat  # noqa: F401  Ensures NumPy compatibility shims are applied.
 import numpy as np
 from filterpy.kalman import KalmanFilter
 
-BBox = Tuple[int, int, int, int]
+from common.geometry import box_center, core_center, dilate_box
+from tracker.costs import class_mismatch_penalty, normalized_l2, within_asym_scale_gate
+
+BBox = Tuple[float, float, float, float]
 
 
 def iou(bb_test: BBox, bb_gt: BBox) -> float:
@@ -69,6 +72,7 @@ class KalmanBoxTracker:
         self.age = 0
         self.label = label
         self.score = score
+        self.last_detection: BBox = tuple(map(float, bbox))
         self._update_bbox(bbox)
 
     @staticmethod
@@ -91,7 +95,7 @@ class KalmanBoxTracker:
         y1 = cy - h / 2.0
         x2 = cx + w / 2.0
         y2 = cy + h / 2.0
-        return int(x1), int(y1), int(x2), int(y2)
+        return float(x1), float(y1), float(x2), float(y2)
 
     def _update_bbox(self, bbox: BBox) -> None:
         self.kf.x[:4] = self.xyxy_to_cxysr(bbox).reshape(-1, 1)
@@ -110,88 +114,207 @@ class KalmanBoxTracker:
         self.hit_streak += 1
         self.label = label
         self.score = score
+        self.last_detection = tuple(map(float, bbox))
         measurement = self.xyxy_to_cxysr(bbox)
         self.kf.update(measurement)
 
     def get_state(self) -> Tuple[BBox, str, float]:
         bbox = self.cxysr_to_xyxy(self.kf.x[:4].reshape(-1))
-        return bbox, self.label, self.score
+        ix1, iy1, ix2, iy2 = bbox
+        return (int(ix1), int(iy1), int(ix2), int(iy2)), self.label, self.score
+
+    def current_bbox(self) -> BBox:
+        return self.cxysr_to_xyxy(self.kf.x[:4].reshape(-1))
+
+    def is_active(self) -> bool:
+        return self.time_since_update == 0
+
+    def absorb(self, other: "KalmanBoxTracker") -> None:
+        self.hits = max(self.hits, other.hits)
+        self.hit_streak = max(self.hit_streak, other.hit_streak)
+        self.score = max(self.score, other.score)
+        if other.time_since_update == 0:
+            self.last_detection = other.last_detection
+
+
+def _merge_dict(defaults: Dict[str, float | bool], override: Dict[str, float | bool] | None) -> Dict[str, float | bool]:
+    cfg = dict(defaults)
+    if override:
+        cfg.update({k: override[k] for k in override if k in cfg})
+        for key, value in override.items():
+            if key not in cfg:
+                cfg[key] = value
+    return cfg
 
 
 class SORT:
-    """Simple Online Realtime Tracking."""
+    """Simple Online Realtime Tracking with prop-robust association tweaks."""
 
-    def __init__(self, iou_threshold: float = 0.3, max_age: int = 10, min_hits: int = 2):
-        self.iou_threshold = float(iou_threshold)
+    def __init__(
+        self,
+        iou_threshold: float = 0.3,
+        iou_th: float | None = None,
+        max_age: int = 10,
+        min_hits: int = 2,
+        class_consistency: Dict[str, float | bool] | None = None,
+        core_center: Dict[str, float | bool] | None = None,
+        scale_gate: Dict[str, float | bool] | None = None,
+        dilate_for_assoc: Dict[str, float | bool] | None = None,
+        duplicate_merge: Dict[str, float | bool] | None = None,
+    ):
+        self.iou_threshold = float(iou_threshold if iou_th is None else iou_th)
         self.max_age = int(max_age)
         self.min_hits = int(min_hits)
         self.trackers: List[KalmanBoxTracker] = []
+        self.class_consistency = _merge_dict(
+            {"enabled": False, "penalty": 1_000_000.0}, class_consistency
+        )
+        self.core_center = _merge_dict({"enabled": False, "shrink": 0.3}, core_center)
+        self.scale_gate = _merge_dict(
+            {"enabled": False, "grow_tol": 1.6, "shrink_tol": 0.6}, scale_gate
+        )
+        self.dilate_for_assoc = _merge_dict(
+            {"enabled": False, "dx": 0.15, "dy": 0.05}, dilate_for_assoc
+        )
+        self.duplicate_merge = _merge_dict(
+            {"enabled": False, "iou_thresh": 0.6, "min_frames": 3, "same_class_only": True},
+            duplicate_merge,
+        )
 
-    def update(self, detections: List[Tuple[BBox, float, str]]) -> List[Tuple[int, BBox, str, float]]:
+    def update(
+        self,
+        detections: List[Tuple[BBox, float, str]],
+        img_size: Tuple[int, int] | None = None,
+    ) -> List[Tuple[int, BBox, str, float]]:
         """Update tracker state.
 
         Args:
             detections: List of tuples ``((x1, y1, x2, y2), confidence, label)``.
+            img_size: Optional ``(width, height)`` tuple for normalization.
 
         Returns:
             List of tuples ``(track_id, bbox, label, score)`` for active tracks.
         """
 
+        if img_size is not None:
+            frame_norm: Iterable[float] | None = (max(1.0, img_size[0]), max(1.0, img_size[1]))
+        else:
+            frame_norm = None
+
         predictions: List[Tuple[KalmanBoxTracker, BBox]] = []
         for tracker in self.trackers:
             predictions.append((tracker, tracker.predict()))
 
+        unmatched_tracks = set(range(len(predictions)))
+        unmatched_dets = set(range(len(detections)))
+        matches: List[Tuple[int, int]] = []
+
         if detections and predictions:
-            iou_matrix = np.zeros((len(detections), len(predictions)), dtype=float)
-            for det_idx, (bbox, _, _) in enumerate(detections):
-                for trk_idx, (_, trk_bbox) in enumerate(predictions):
-                    iou_matrix[det_idx, trk_idx] = iou(bbox, trk_bbox)
+            track_order = sorted(range(len(predictions)), key=lambda idx: -predictions[idx][0].age)
+            for trk_idx in track_order:
+                tracker, pred_box = predictions[trk_idx]
+                assoc_box = pred_box
+                pred_w = max(1.0, pred_box[2] - pred_box[0])
+                pred_h = max(1.0, pred_box[3] - pred_box[1])
 
-            assigned_dets = set()
-            assigned_trks = set()
-            pairs: List[Tuple[int, int]] = []
-            while True:
-                det_idx, trk_idx = np.unravel_index(np.argmax(iou_matrix), iou_matrix.shape)
-                if iou_matrix[det_idx, trk_idx] < self.iou_threshold:
-                    break
-                pairs.append((det_idx, trk_idx))
-                assigned_dets.add(det_idx)
-                assigned_trks.add(trk_idx)
-                iou_matrix[det_idx, :] = -1
-                iou_matrix[:, trk_idx] = -1
+                if self.dilate_for_assoc.get("enabled") and tracker.label == "person":
+                    assoc_box = dilate_box(
+                        *assoc_box,
+                        float(self.dilate_for_assoc.get("dx", 0.0)),
+                        float(self.dilate_for_assoc.get("dy", 0.0)),
+                    )
 
-            for det_idx, trk_idx in pairs:
-                bbox, score, label = detections[det_idx]
-                tracker, _ = predictions[trk_idx]
-                tracker.update(bbox, label, score)
+                tcx, tcy = box_center(*assoc_box)
+                if self.core_center.get("enabled") and tracker.label == "person":
+                    tcx, tcy = core_center(
+                        *assoc_box,
+                        float(self.core_center.get("shrink", 0.3)),
+                    )
 
-            for det_idx, (bbox, score, label) in enumerate(detections):
-                if det_idx in assigned_dets:
-                    continue
-                self.trackers.append(KalmanBoxTracker(bbox, label, score))
+                best_det = None
+                best_score = -np.inf
+                best_iou = 0.0
+                for det_idx in list(unmatched_dets):
+                    det_bbox, det_score, det_label = detections[det_idx]
+                    det_box = tuple(map(float, det_bbox))
 
-            survivors: List[KalmanBoxTracker] = []
-            for trk_idx, (tracker, _) in enumerate(predictions):
-                if trk_idx in assigned_trks:
-                    survivors.append(tracker)
-                else:
-                    tracker.time_since_update += 1
-                    tracker.hit_streak = max(0, tracker.hit_streak - 1)
-                    if tracker.time_since_update <= self.max_age:
-                        survivors.append(tracker)
-            self.trackers = survivors
+                    if self.class_consistency.get("enabled"):
+                        penalty = class_mismatch_penalty(
+                            tracker.label,
+                            det_label,
+                            float(self.class_consistency.get("penalty", 0.0)),
+                        )
+                        if penalty > 0:
+                            continue
 
-        else:
-            for tracker in list(self.trackers):
-                tracker.time_since_update += 1
+                    if self.scale_gate.get("enabled") and tracker.label == "person":
+                        det_w = max(1.0, det_box[2] - det_box[0])
+                        det_h = max(1.0, det_box[3] - det_box[1])
+                        if not within_asym_scale_gate(
+                            (pred_w, pred_h),
+                            (det_w, det_h),
+                            float(self.scale_gate.get("grow_tol", 1.6)),
+                            float(self.scale_gate.get("shrink_tol", 0.6)),
+                        ):
+                            continue
 
-            for bbox, score, label in detections:
-                self.trackers.append(KalmanBoxTracker(bbox, label, score))
+                    dcx, dcy = box_center(*det_box)
+                    if self.core_center.get("enabled") and det_label == "person":
+                        dcx, dcy = core_center(
+                            *det_box,
+                            float(self.core_center.get("shrink", 0.3)),
+                        )
 
-            self.trackers = [t for t in self.trackers if t.time_since_update <= self.max_age]
+                    iou_score = iou(det_box, assoc_box)
+                    if iou_score <= 0:
+                        continue
+
+                    norm = frame_norm or (pred_w, pred_h)
+                    center_cost = normalized_l2((tcx, tcy), (dcx, dcy), norm)
+                    score = iou_score - center_cost
+                    if score > best_score:
+                        best_score = score
+                        best_det = det_idx
+                        best_iou = iou_score
+
+                if best_det is not None and best_iou >= self.iou_threshold:
+                    matches.append((trk_idx, best_det))
+                    unmatched_tracks.discard(trk_idx)
+                    unmatched_dets.discard(best_det)
+
+        for trk_idx, det_idx in matches:
+            tracker, _ = predictions[trk_idx]
+            det_bbox, det_score, det_label = detections[det_idx]
+            tracker.update(tuple(map(float, det_bbox)), det_label, det_score)
+
+        for trk_idx in unmatched_tracks:
+            tracker, _ = predictions[trk_idx]
+            tracker.hit_streak = max(0, tracker.hit_streak - 1)
+
+        for det_idx in sorted(unmatched_dets):
+            det_bbox, det_score, det_label = detections[det_idx]
+            self.trackers.append(
+                KalmanBoxTracker(tuple(map(float, det_bbox)), det_label, det_score)
+            )
+
+        survivors: List[KalmanBoxTracker] = []
+        for tracker in self.trackers:
+            if tracker.time_since_update <= self.max_age:
+                survivors.append(tracker)
+        self.trackers = survivors
+
+        if self.duplicate_merge.get("enabled"):
+            removed_ids = merge_nearby_tracks(
+                self.trackers,
+                float(self.duplicate_merge.get("iou_thresh", 0.6)),
+                int(self.duplicate_merge.get("min_frames", 3)),
+                bool(self.duplicate_merge.get("same_class_only", True)),
+            )
+            if removed_ids:
+                self.trackers = [t for t in self.trackers if t.id not in removed_ids]
 
         outputs: List[Tuple[int, BBox, str, float]] = []
-        survivors: List[KalmanBoxTracker] = []
+        survivors = []
         for tracker in self.trackers:
             if tracker.hits >= self.min_hits or tracker.time_since_update == 0:
                 bbox, label, score = tracker.get_state()
@@ -200,3 +323,29 @@ class SORT:
                 survivors.append(tracker)
         self.trackers = survivors
         return outputs
+
+
+def merge_nearby_tracks(
+    tracks: Iterable[KalmanBoxTracker],
+    iou_thresh: float,
+    min_frames: int,
+    same_class_only: bool = True,
+) -> set[int]:
+    alive = [t for t in tracks if t.is_active() and t.hits >= min_frames]
+    alive.sort(key=lambda t: -t.age)
+    removed: set[int] = set()
+    for i, anchor in enumerate(alive):
+        if anchor.id in removed:
+            continue
+        anchor_box = anchor.current_bbox()
+        for other in alive[i + 1 :]:
+            if other.id in removed or other.id == anchor.id:
+                continue
+            if other.hits < min_frames:
+                continue
+            if same_class_only and anchor.label != other.label:
+                continue
+            if iou(anchor_box, other.current_bbox()) >= iou_thresh:
+                anchor.absorb(other)
+                removed.add(other.id)
+    return removed


### PR DESCRIPTION
## Summary
- add geometry and cost helpers to support person-with-prop association tweaks
- harden SORT matching with class consistency, core-centre distance, scale gating, dilation, and duplicate merging
- expose new tracker knobs in edge configs, document them, and cover helpers with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d301865bb4832d835d3630a8ee778c