### PR TITLE
Scale measurement noise to image-relative tolerances

### DIFF
--- a/configs/edge_pi5_stage1.yaml
+++ b/configs/edge_pi5_stage1.yaml
@@ -38,8 +38,8 @@ tracker:
   w_app: 0.0
   q_pos: 1.0
   q_sz: 2.0
-  r_pos: 3.0
-  r_sz: 8.0
+  r_pos: 0.12
+  r_sz: 0.4
   merge_dups:
     enabled: true
     iou_thr: 0.8

--- a/tests/test_db_tracker_regression.py
+++ b/tests/test_db_tracker_regression.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import pathlib
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tracker.db_tracker import DBTracker
+
+
+def test_dbtracker_large_shift_keeps_track() -> None:
+    tracker = DBTracker(
+        max_age=10,
+        min_hits=1,
+        center_gate_frac=0.25,
+        r_pos=0.25,
+        r_sz=0.5,
+    )
+
+    det0 = ((100, 120, 220, 320), 0.9, "person")
+    outputs0 = tracker.update([det0], img_size=(640, 480))
+    assert len(outputs0) == 1
+    track_id = outputs0[0][0]
+
+    det1 = ((250, 120, 370, 320), 0.9, "person")
+    outputs1 = tracker.update([det1], img_size=(640, 480))
+    assert len(outputs1) == 1
+    assert outputs1[0][0] == track_id


### PR DESCRIPTION
## Summary
- scale Kalman measurement noise using fractional tolerances tied to the image diagonal and predicted box size
- treat r_pos and r_sz as fractional tolerances in DBTracker and update the default edge_pi5_stage1 tracker config
- add a regression test that keeps a single track id across a 150 px shift when using a relaxed center gate

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d30b43bdc4832d9284039de36aecd6