### PR TITLE
Document ZeroMQ streaming workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,41 @@ pip install -r requirements.txt
 python apps/run_edge.py -c configs/edge_pi5.yaml
 ```
 
+## Streaming frames over ZeroMQ
+Scotty can ingest frames published over the network via the `framebus` helper,
+which uses [`imagezmq`](https://github.com/jeffbass/imagezmq) (ZeroMQ PUB/SUB)
+to broadcast JPEG frames and metadata.
+
+1. **Start a publisher** on the machine with camera access:
+   ```bash
+   source .venv/bin/activate
+   # Publish from a Pi camera (Picamera2)
+   python -m framebus.hub --source picam
+
+   # or stream a video file / USB webcam while developing on a laptop
+   python -m framebus.hub --source /path/to/video.mp4 --loop
+   ```
+   Useful options include `--endpoint tcp://*:5555` to change the bind
+   address/port, `--camera-id my_cam` to override the camera identifier, and
+   `--fps 5` to throttle the publish rate (set `0` to disable throttling).
+
+2. **Configure the edge consumer** to subscribe to the stream by setting the
+   source in your YAML config. For example:
+   ```yaml
+   source:
+     kind: zmq
+     endpoint: tcp://127.0.0.1:5555
+   ```
+
+3. **Run the pipeline** as usual:
+   ```bash
+   python apps/run_edge.py -c configs/edge_pi5_stage1.yaml
+   ```
+
+Multiple consumers can subscribe to the same publisher simultaneously (HUD,
+recorder, analytics, etc.). Switch back to a direct camera feed by setting
+`source.kind: camera` in your config.
+
 ## Repository layout
 - `intuitus/`    – optional motion/ROI gating modules
 - `quiddity/`    – detectors/classifiers


### PR DESCRIPTION
## Summary
- document how to use the framebus helper to stream frames to Scotty over ZeroMQ
- add configuration and runtime examples to the main README

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d44c05c068832d8fd90058e821617b