### PR TITLE
Launch FrameBus hub from run_edge

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,35 +22,29 @@ Scotty can ingest frames published over the network via the `framebus` helper,
 which uses [`imagezmq`](https://github.com/jeffbass/imagezmq) (ZeroMQ PUB/SUB)
 to broadcast JPEG frames and metadata.
 
-1. **Start a publisher** on the machine with camera access:
-   ```bash
-   source .venv/bin/activate
-   # Publish from a Pi camera (Picamera2)
-   python -m framebus.hub --source picam
-
-   # or stream a video file / USB webcam while developing on a laptop
-   python -m framebus.hub --source /path/to/video.mp4 --loop
-   ```
-   Useful options include `--endpoint tcp://*:5555` to change the bind
-   address/port, `--camera-id my_cam` to override the camera identifier, and
-   `--fps 5` to throttle the publish rate (set `0` to disable throttling).
-
-2. **Configure the edge consumer** to subscribe to the stream by setting the
-   source in your YAML config. For example:
+1. **Configure the edge consumer** to subscribe to the stream by setting the
+   source in your YAML config. `apps/run_edge.py` now launches the publisher on
+   your behalf:
    ```yaml
    source:
      kind: zmq
      endpoint: tcp://127.0.0.1:5555
+     publisher:
+       source: /path/to/video.mp4  # defaults to picam when omitted
+       loop: true                  # optional
+       fps: 5                      # optional, defaults to edge.fps
+       camera_id: dev_cam         # optional override
    ```
 
-3. **Run the pipeline** as usual:
+2. **Run the pipeline** as usual:
    ```bash
    python apps/run_edge.py -c configs/edge_pi5_stage1.yaml
    ```
 
 Multiple consumers can subscribe to the same publisher simultaneously (HUD,
 recorder, analytics, etc.). Switch back to a direct camera feed by setting
-`source.kind: camera` in your config.
+`source.kind: camera` in your config. Override the bind address by setting
+`source.bind` (defaults to `tcp://*:<port>` based on the consumer endpoint).
 
 ## Repository layout
 - `intuitus/`    – optional motion/ROI gating modules

--- a/framebus/README.md
+++ b/framebus/README.md
@@ -6,28 +6,27 @@ Single producer (camera) → many consumers via ZeroMQ.
 - Payload: JPEG frames + JSON metadata header
 - Metadata: frame_id, ts, camera_id, w, h, fmt
 
-## Start the publisher
-```
-. venv/bin/activate
-# Picamera2 on-device
-python3 -m framebus.hub --source picam
-
-# OR stream a video/file/webcam when developing on a laptop
-python3 -m framebus.hub --source /path/to/video.mp4 --loop
-```
-
-Other useful options:
-
-- `--endpoint tcp://*:5555` – change the bind address/port.
-- `--camera-id my_cam` – override the camera identifier stamped into metadata.
-- `--fps 5` – throttle publish rate (set `0` to disable throttling).
-
 ## Start an edge consumer
 ```
 python3 apps/run_edge.py --config configs/edge_pi5_stage1.yaml
 ```
 
-Ensure the config has `source.kind: zmq` and `source.endpoint: tcp://127.0.0.1:5555`.
+`apps/run_edge.py` now launches the hub automatically when `source.kind: zmq` is
+configured. The default publisher uses Picamera2 (`--source picam`), but you can
+override it with a `publisher` block in your YAML:
+
+```yaml
+source:
+  kind: zmq
+  endpoint: tcp://127.0.0.1:5555
+  publisher:
+    source: /path/to/video.mp4
+    loop: true
+    fps: 5
+```
+
+Set `source.bind` to override the bind address (defaults to `tcp://*:<port>`)
+and `publisher.camera_id` to inject a specific ID.
 
 ## Notes
 - Consumers skip ahead if they lag; hub stays real-time.


### PR DESCRIPTION
## Summary
- launch the FrameBus hub from `apps/run_edge.py` when using a ZMQ source, logging connection progress and every 10th frame while cleaning up the child process
- allow overriding hub options via `source.publisher` and document the behavior in the README files

## Testing
- python -m compileall apps/run_edge.py

------
https://chatgpt.com/codex/tasks/task_e_68d45092d58c832dadadbd41f8b54937