### PR TITLE
Retry initial camera read before failing

### DIFF
--- a/common/video_utils.py
+++ b/common/video_utils.py
@@ -72,8 +72,13 @@ def open_source(src, fps):
     if not cap.isOpened():
         raise SystemExit(f"Could not open source: {src}")
 
+    deadline = time.time() + 2.0
     ok, frame = cap.read()
-    if not ok:
+    while (not ok or frame is None) and time.time() < deadline:
+        time.sleep(0.05)
+        ok, frame = cap.read()
+
+    if not ok or frame is None:
         cap.release()
         raise SystemExit(f"Failed to read first frame from source: {src}")
     height, width = frame.shape[:2]


### PR DESCRIPTION
## Summary
- retry reading from cv2 camera sources for up to two seconds before failing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e016e067d4832d9d1f99f67287b201