### PR TITLE
Default Pi 5 edge config to picamera input

### DIFF
--- a/common/video_utils.py
+++ b/common/video_utils.py
@@ -72,8 +72,13 @@ def open_source(src, fps):
     if not cap.isOpened():
         raise SystemExit(f"Could not open source: {src}")
 
+    deadline = time.time() + 2.0
     ok, frame = cap.read()
-    if not ok:
+    while (not ok or frame is None) and time.time() < deadline:
+        time.sleep(0.05)
+        ok, frame = cap.read()
+
+    if not ok or frame is None:
         cap.release()
         raise SystemExit(f"Failed to read first frame from source: {src}")
     height, width = frame.shape[:2]

--- a/configs/edge_pi5.yaml
+++ b/configs/edge_pi5.yaml
@@ -1,6 +1,7 @@
 edge:
   cam_id: "pi5_cam_a"
   fps: 1.0
+  source: "picam"
   emit_jsonl: "data/detections.jsonl"
   mqtt: null  # e.g., "mqtts://user:pass@host:8883/topic"
   web:


### PR DESCRIPTION
## Summary
- configure the Pi 5 edge profile to read from the picamera source so the MIPI feed reaches the pipeline

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e016e067d4832d9d1f99f67287b201